### PR TITLE
Add Chrome extension to save ChatGPT and Claude output to Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-＃README
+# README
+
+This repository includes a sample Chrome extension that sends ChatGPT or Claude responses to Obsidian using the `obsidian://` URI scheme.
+
+## Usage
+1. Open `chrome://extensions` and enable Developer Mode.
+2. Choose "Load unpacked" and select the `obsidian-extension` folder.
+3. Open ChatGPT or Claude and click the "Obsidianへ保存" button that appears in the bottom-right corner.
+4. Obsidian will open with a new note containing the latest answer.

--- a/obsidian-extension/background.js
+++ b/obsidian-extension/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "SAVE_OBSIDIAN") {
+    const title = `ChatGPT-Note-${Date.now()}`;
+    const content = encodeURIComponent(message.payload);
+    const obsidianUrl = `obsidian://new?file=${title}.md&content=${content}`;
+    chrome.tabs.create({ url: obsidianUrl });
+  }
+});

--- a/obsidian-extension/content.js
+++ b/obsidian-extension/content.js
@@ -1,0 +1,46 @@
+function getLatestAnswer() {
+  const chatGPT = document.querySelector("div.markdown");
+  if (chatGPT) return chatGPT.innerText;
+
+  const claude = document.querySelector('[data-testid="bot-message-content"]');
+  if (claude) return claude.innerText;
+
+  return null;
+}
+
+function createButton() {
+  if (document.getElementById("obsidian-save-btn")) return;
+
+  const button = document.createElement("button");
+  button.id = "obsidian-save-btn";
+  button.textContent = "Obsidianへ保存";
+  Object.assign(button.style, {
+    position: "fixed",
+    bottom: "20px",
+    right: "20px",
+    zIndex: 9999,
+    padding: "8px 12px",
+    backgroundColor: "#3b82f6",
+    color: "#fff",
+    border: "none",
+    borderRadius: "4px",
+    cursor: "pointer",
+  });
+
+  button.addEventListener("click", () => {
+    const text = getLatestAnswer();
+    if (text) {
+      chrome.runtime.sendMessage({ type: "SAVE_OBSIDIAN", payload: text });
+    } else {
+      alert("保存できるメッセージが見つかりませんでした。");
+    }
+  });
+
+  document.body.appendChild(button);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", createButton);
+} else {
+  createButton();
+}

--- a/obsidian-extension/manifest.json
+++ b/obsidian-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "LLM to Obsidian",
+  "description": "Save ChatGPT and Claude outputs to Obsidian",
+  "version": "0.1",
+  "manifest_version": 3,
+  "permissions": ["scripting", "activeTab"],
+  "background": { "service_worker": "background.js" },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://claude.ai/*"
+      ],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_title": "Save to Obsidian"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample Chrome extension that captures ChatGPT/Claude responses and opens a new Obsidian note via `obsidian://` link
- document steps for loading the extension
- ensure the save button renders after page load with visible styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c85401574833284f91647e958e9e0