### PR TITLE
Add Chrome extension to save ChatGPT and Claude output to Obsidian

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This repository includes a sample Chrome extension that sends ChatGPT or Claude 
 ## Usage
 1. Open `chrome://extensions` and enable Developer Mode.
 2. Choose "Load unpacked" and select the `obsidian-extension` folder.
-3. Open ChatGPT or Claude and click the "Obsidianへ保存" button that appears in the bottom-right corner.
+3. Open ChatGPT or Claude and click the "Obsidianへ保存" button in the action menu of the latest reply.
 4. Obsidian will open with a new note containing the latest answer.

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ This repository includes a sample Chrome extension that sends ChatGPT or Claude 
 ## Usage
 1. Open `chrome://extensions` and enable Developer Mode.
 2. Choose "Load unpacked" and select the `obsidian-extension` folder.
-3. Open ChatGPT or Claude and click the "Obsidianへ保存" button in the action menu of the latest reply.
-4. Obsidian will open with a new note containing the latest answer.
+3. In `background.js`, replace `YOUR_VAULT_NAME` with the name of your Obsidian vault.
+4. Open ChatGPT or Claude and click the extension's toolbar icon.
+5. Obsidian will open with a new note containing the latest answer.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-＃README
+# README
+
+This repository includes a sample Chrome extension that sends ChatGPT or Claude responses to Obsidian using the `obsidian://` URI scheme.
+
+## Usage
+1. Open `chrome://extensions` and enable Developer Mode.
+2. Choose "Load unpacked" and select the `obsidian-extension` folder.
+3. Open ChatGPT or Claude and click the "Obsidianへ保存" button that appears in the bottom-right corner.
+4. Obsidian will open with a new note containing the latest answer.

--- a/obsidian-extension/background.js
+++ b/obsidian-extension/background.js
@@ -1,8 +1,31 @@
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === "SAVE_OBSIDIAN") {
-    const title = `ChatGPT-Note-${Date.now()}`;
-    const content = encodeURIComponent(message.payload);
-    const obsidianUrl = `obsidian://new?file=${title}.md&content=${content}`;
-    chrome.tabs.create({ url: obsidianUrl });
+// Respond to toolbar icon clicks
+chrome.action.onClicked.addListener((tab) => {
+  if (!tab.id) return;
+  // Ensure script runs only on ChatGPT or Claude pages
+  if (!/chat\.openai\.com|claude\.ai/.test(tab.url || "")) {
+    console.log("Unsupported page");
+    return;
   }
+
+  chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    files: ['content.js']
+  }, (results) => {
+    if (chrome.runtime.lastError || !results || !results.length) {
+      console.error('Script injection failed:', chrome.runtime.lastError);
+      return;
+    }
+    const text = results[0].result;
+    if (!text) {
+      console.warn('No text found to save');
+      return;
+    }
+
+    const vaultName = 'YOUR_VAULT_NAME'; // replace with your Obsidian vault
+    const encodedText = encodeURIComponent(text);
+    const today = new Date().toISOString().slice(0, 10);
+    const fileName = encodeURIComponent(`LLM Note ${today}`);
+    const obsidianUri = `obsidian://new?vault=${vaultName}&file=${fileName}&content=${encodedText}`;
+    chrome.tabs.create({ url: obsidianUri });
+  });
 });

--- a/obsidian-extension/background.js
+++ b/obsidian-extension/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "SAVE_OBSIDIAN") {
+    const title = `ChatGPT-Note-${Date.now()}`;
+    const content = encodeURIComponent(message.payload);
+    const obsidianUrl = `obsidian://new?file=${title}.md&content=${content}`;
+    chrome.tabs.create({ url: obsidianUrl });
+  }
+});

--- a/obsidian-extension/content.js
+++ b/obsidian-extension/content.js
@@ -8,39 +8,67 @@ function getLatestAnswer() {
   return null;
 }
 
-function createButton() {
-  if (document.getElementById("obsidian-save-btn")) return;
+function insertActionButton() {
+  const buttons = document.querySelectorAll('button[data-testid="copy-turn-action-button"]');
+  const actionBar = buttons.length ? buttons[buttons.length - 1].parentElement : null;
+  if (!actionBar || actionBar.querySelector('#obsidian-save-btn')) return;
 
-  const button = document.createElement("button");
-  button.id = "obsidian-save-btn";
-  button.textContent = "Obsidianへ保存";
-  Object.assign(button.style, {
-    position: "fixed",
-    bottom: "20px",
-    right: "20px",
-    zIndex: 9999,
-    padding: "8px 12px",
-    backgroundColor: "#3b82f6",
-    color: "#fff",
-    border: "none",
-    borderRadius: "4px",
-    cursor: "pointer",
-  });
-
-  button.addEventListener("click", () => {
+  const button = document.createElement('button');
+  button.id = 'obsidian-save-btn';
+  button.className = 'text-token-text-secondary hover:bg-token-bg-secondary rounded-lg';
+  button.setAttribute('aria-label', 'Obsidianへ保存');
+  button.innerHTML = '<span class="touch:w-10 flex h-8 w-8 items-center justify-center">💾</span>';
+  button.addEventListener('click', () => {
     const text = getLatestAnswer();
     if (text) {
-      chrome.runtime.sendMessage({ type: "SAVE_OBSIDIAN", payload: text });
+      chrome.runtime.sendMessage({ type: 'SAVE_OBSIDIAN', payload: text });
     } else {
-      alert("保存できるメッセージが見つかりませんでした。");
+      alert('保存できるメッセージが見つかりませんでした。');
     }
   });
+  actionBar.appendChild(button);
+}
 
+function createFallbackButton() {
+  if (document.getElementById('obsidian-save-btn')) return;
+  const button = document.createElement('button');
+  button.id = 'obsidian-save-btn';
+  button.textContent = 'Obsidianへ保存';
+  Object.assign(button.style, {
+    position: 'fixed',
+    bottom: '20px',
+    right: '20px',
+    zIndex: 9999,
+    padding: '8px 12px',
+    backgroundColor: '#3b82f6',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+  });
+  button.addEventListener('click', () => {
+    const text = getLatestAnswer();
+    if (text) {
+      chrome.runtime.sendMessage({ type: 'SAVE_OBSIDIAN', payload: text });
+    } else {
+      alert('保存できるメッセージが見つかりませんでした。');
+    }
+  });
   document.body.appendChild(button);
 }
 
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", createButton);
+function init() {
+  insertActionButton();
+  if (!document.getElementById('obsidian-save-btn')) {
+    createFallbackButton();
+  }
+}
+
+const observer = new MutationObserver(insertActionButton);
+observer.observe(document.body, { childList: true, subtree: true });
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
 } else {
-  createButton();
+  init();
 }

--- a/obsidian-extension/content.js
+++ b/obsidian-extension/content.js
@@ -1,80 +1,13 @@
-function getLatestAnswer() {
+(() => {
+  // Try to grab latest ChatGPT answer
   const chatGPTBlocks = document.querySelectorAll('div.markdown');
   const chatGPT = chatGPTBlocks[chatGPTBlocks.length - 1];
   if (chatGPT) return chatGPT.innerText.trim();
 
-  // Claude's answer container uses the `font-claude-response` class
-  const claudeBlocks = document.querySelectorAll('.font-claude-response');
+  // Fallback to Claude's latest answer
+  const claudeBlocks = document.querySelectorAll('div.grid.grid-cols-1');
   const claude = claudeBlocks[claudeBlocks.length - 1];
-  if (claude) {
-    const content = claude.querySelector('.grid') || claude;
-    return content.innerText.trim();
-  }
+  if (claude) return claude.innerText.trim();
 
   return null;
-}
-
-function insertActionButton() {
-  const buttons = document.querySelectorAll('button[data-testid="copy-turn-action-button"]');
-  const actionBar = buttons.length ? buttons[buttons.length - 1].parentElement : null;
-  if (!actionBar || actionBar.querySelector('#obsidian-save-btn')) return;
-
-  const button = document.createElement('button');
-  button.id = 'obsidian-save-btn';
-  button.className = 'text-token-text-secondary hover:bg-token-bg-secondary rounded-lg';
-  button.setAttribute('aria-label', 'Obsidianへ保存');
-  button.innerHTML = '<span class="touch:w-10 flex h-8 w-8 items-center justify-center">💾</span>';
-  button.addEventListener('click', () => {
-    const text = getLatestAnswer();
-    if (text) {
-      chrome.runtime.sendMessage({ type: 'SAVE_OBSIDIAN', payload: text });
-    } else {
-      alert('保存できるメッセージが見つかりませんでした。');
-    }
-  });
-  actionBar.appendChild(button);
-}
-
-function createFallbackButton() {
-  if (document.getElementById('obsidian-save-btn')) return;
-  const button = document.createElement('button');
-  button.id = 'obsidian-save-btn';
-  button.textContent = 'Obsidianへ保存';
-  Object.assign(button.style, {
-    position: 'fixed',
-    bottom: '20px',
-    right: '20px',
-    zIndex: 9999,
-    padding: '8px 12px',
-    backgroundColor: '#3b82f6',
-    color: '#fff',
-    border: 'none',
-    borderRadius: '4px',
-    cursor: 'pointer',
-  });
-  button.addEventListener('click', () => {
-    const text = getLatestAnswer();
-    if (text) {
-      chrome.runtime.sendMessage({ type: 'SAVE_OBSIDIAN', payload: text });
-    } else {
-      alert('保存できるメッセージが見つかりませんでした。');
-    }
-  });
-  document.body.appendChild(button);
-}
-
-function init() {
-  insertActionButton();
-  if (!document.getElementById('obsidian-save-btn')) {
-    createFallbackButton();
-  }
-}
-
-const observer = new MutationObserver(insertActionButton);
-observer.observe(document.body, { childList: true, subtree: true });
-
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', init);
-} else {
-  init();
-}
+})();

--- a/obsidian-extension/content.js
+++ b/obsidian-extension/content.js
@@ -1,0 +1,46 @@
+function getLatestAnswer() {
+  const chatGPT = document.querySelector("div.markdown");
+  if (chatGPT) return chatGPT.innerText;
+
+  const claude = document.querySelector('[data-testid="bot-message-content"]');
+  if (claude) return claude.innerText;
+
+  return null;
+}
+
+function createButton() {
+  if (document.getElementById("obsidian-save-btn")) return;
+
+  const button = document.createElement("button");
+  button.id = "obsidian-save-btn";
+  button.textContent = "Obsidianへ保存";
+  Object.assign(button.style, {
+    position: "fixed",
+    bottom: "20px",
+    right: "20px",
+    zIndex: 9999,
+    padding: "8px 12px",
+    backgroundColor: "#3b82f6",
+    color: "#fff",
+    border: "none",
+    borderRadius: "4px",
+    cursor: "pointer",
+  });
+
+  button.addEventListener("click", () => {
+    const text = getLatestAnswer();
+    if (text) {
+      chrome.runtime.sendMessage({ type: "SAVE_OBSIDIAN", payload: text });
+    } else {
+      alert("保存できるメッセージが見つかりませんでした。");
+    }
+  });
+
+  document.body.appendChild(button);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", createButton);
+} else {
+  createButton();
+}

--- a/obsidian-extension/content.js
+++ b/obsidian-extension/content.js
@@ -1,9 +1,15 @@
 function getLatestAnswer() {
-  const chatGPT = document.querySelector("div.markdown");
-  if (chatGPT) return chatGPT.innerText;
+  const chatGPTBlocks = document.querySelectorAll('div.markdown');
+  const chatGPT = chatGPTBlocks[chatGPTBlocks.length - 1];
+  if (chatGPT) return chatGPT.innerText.trim();
 
-  const claude = document.querySelector('[data-testid="bot-message-content"]');
-  if (claude) return claude.innerText;
+  // Claude's answer container uses the `font-claude-response` class
+  const claudeBlocks = document.querySelectorAll('.font-claude-response');
+  const claude = claudeBlocks[claudeBlocks.length - 1];
+  if (claude) {
+    const content = claude.querySelector('.grid') || claude;
+    return content.innerText.trim();
+  }
 
   return null;
 }

--- a/obsidian-extension/manifest.json
+++ b/obsidian-extension/manifest.json
@@ -1,20 +1,13 @@
 {
-  "name": "LLM to Obsidian",
-  "description": "Save ChatGPT and Claude outputs to Obsidian",
-  "version": "0.1",
   "manifest_version": 3,
-  "permissions": ["scripting", "activeTab"],
-  "background": { "service_worker": "background.js" },
-  "content_scripts": [
-    {
-      "matches": [
-        "https://chat.openai.com/*",
-        "https://claude.ai/*"
-      ],
-      "js": ["content.js"]
-    }
-  ],
+  "name": "LLM to Obsidian",
+  "version": "0.2",
+  "description": "Send ChatGPT or Claude output to Obsidian",
+  "permissions": ["activeTab", "scripting"],
   "action": {
-    "default_title": "Save to Obsidian"
+    "default_title": "Send to Obsidian"
+  },
+  "background": {
+    "service_worker": "background.js"
   }
 }

--- a/obsidian-extension/manifest.json
+++ b/obsidian-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "LLM to Obsidian",
+  "description": "Save ChatGPT and Claude outputs to Obsidian",
+  "version": "0.1",
+  "manifest_version": 3,
+  "permissions": ["scripting", "activeTab"],
+  "background": { "service_worker": "background.js" },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chat.openai.com/*",
+        "https://claude.ai/*"
+      ],
+      "js": ["content.js"]
+    }
+  ],
+  "action": {
+    "default_title": "Save to Obsidian"
+  }
+}


### PR DESCRIPTION
## Summary
- add sample Chrome extension that captures ChatGPT/Claude responses and opens a new Obsidian note via `obsidian://` link
- document steps for loading the extension
- ensure the save button renders after page load with visible styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c85401574833284f91647e958e9e0